### PR TITLE
Remove cafe.sunbeam.city from instance list

### DIFF
--- a/source/javascripts/instances.json
+++ b/source/javascripts/instances.json
@@ -11,11 +11,6 @@
       "url": "https://plume.mastodon.host"
     },
     {
-      "name": "Cafe.Sunbeam.City",
-      "description": "A part of the Sunbeam.City cooperative",
-      "url": "https://cafe.sunbeam.city"
-    },
-    {
       "name": "Lorem.Club",
       "description": "A welcoming Plume instance for everyone, run by enthusiasts",
       "url": "https://lorem.club"


### PR DESCRIPTION
A maintainer said: "its been broken for a long time. yeah it should be removed from the list of open instances."

Source: https://social.wake.st/@liaizon/103823067218897008